### PR TITLE
Env var to drive namespace that operator watches

### DIFF
--- a/operator/cmd/vault-operator/main.go
+++ b/operator/cmd/vault-operator/main.go
@@ -19,7 +19,9 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	sdk.Watch("vault.banzaicloud.com/v1alpha1", "Vault", "default", 5)
+	namespace := os.Getenv("WATCH_NAMESPACE")
+	logrus.Infof("watching namespace: %v", namespace)
+	sdk.Watch("vault.banzaicloud.com/v1alpha1", "Vault", namespace, 5)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/operator/cmd/vault-operator/main.go
+++ b/operator/cmd/vault-operator/main.go
@@ -19,12 +19,17 @@ func printVersion() {
 
 func main() {
 	printVersion()
+	
+	resource := "vault.banzaicloud.com/v1alpha1"
+	kind := "Vault"
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
 		logrus.Fatalf("Failed to get watch namespace: %v", err)
 	}
-	logrus.Infof("watching namespace: %v", namespace)
-	sdk.Watch("vault.banzaicloud.com/v1alpha1", "Vault", namespace, 60)
+	resyncPeriod := 5
+	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
+
+	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }

--- a/operator/cmd/vault-operator/main.go
+++ b/operator/cmd/vault-operator/main.go
@@ -19,9 +19,12 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	namespace := os.Getenv("WATCH_NAMESPACE")
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		logrus.Fatalf("Failed to get watch namespace: %v", err)
+	}
 	logrus.Infof("watching namespace: %v", namespace)
-	sdk.Watch("vault.banzaicloud.com/v1alpha1", "Vault", namespace, 5)
+	sdk.Watch("vault.banzaicloud.com/v1alpha1", "Vault", namespace, 60)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }


### PR DESCRIPTION
Currently you can only deploy vault to the default namespace. This change allows you to use an env var to set the namespace that the operator watches for new Vault kubernetes objects.